### PR TITLE
Refactor Centrifugo subscription proxy endpoint

### DIFF
--- a/src/opcua_webhmi_bridge/frontend_messaging.py
+++ b/src/opcua_webhmi_bridge/frontend_messaging.py
@@ -129,7 +129,9 @@ class CentrifugoProxyServer(AsyncTask):
                 self._messaging_writer.put(message)
         elif channel == MessageType.OPC_STATUS:
             self._messaging_writer.put(self.last_opc_status)
-        else:
+        try:
+            MessageType(channel)
+        except ValueError:
             return _error(1001, "Unknown channel")
         return web.json_response({"result": {}})
 

--- a/src/opcua_webhmi_bridge/frontend_messaging.py
+++ b/src/opcua_webhmi_bridge/frontend_messaging.py
@@ -57,7 +57,7 @@ class FrontendMessagingWriter(MessageConsumer[OPCMessage]):
                 command = {
                     "method": "publish",
                     "params": {
-                        "channel": message.message_type,
+                        "channel": message.message_type.value,
                         "data": message.frontend_data,
                     },
                 }

--- a/src/opcua_webhmi_bridge/frontend_messaging.py
+++ b/src/opcua_webhmi_bridge/frontend_messaging.py
@@ -12,6 +12,7 @@ from .library import AsyncTask, MessageConsumer
 from .messages import (
     HeartBeatMessage,
     LinkStatus,
+    MessageType,
     OPCDataChangeMessage,
     OPCStatusMessage,
 )
@@ -110,6 +111,10 @@ class CentrifugoProxyServer(AsyncTask):
 
     async def centrifugo_subscribe(self, request: web.Request) -> web.Response:
         """Handle Centrifugo subscription requests."""
+
+        def _error(code: int, message: str) -> web.Response:
+            return web.json_response({"error": {"code": code, "message": message}})
+
         try:
             context = await request.json()
             channel = context.get("channel")
@@ -118,14 +123,14 @@ class CentrifugoProxyServer(AsyncTask):
         except AttributeError:
             raise web.HTTPBadRequest(reason="Bad request format")
         if channel is None:
-            raise web.HTTPBadRequest(reason="Missing channel field")
-        elif channel == OPCDataChangeMessage.message_type:
+            return _error(1000, "Missing channel field")
+        elif channel == MessageType.OPC_DATA_CHANGE:
             for message in self._last_opc_data.values():
                 self._messaging_writer.put(message)
-        elif channel == OPCStatusMessage.message_type:
+        elif channel == MessageType.OPC_STATUS:
             self._messaging_writer.put(self.last_opc_status)
         else:
-            raise web.HTTPBadRequest(reason="Unknown channel")
+            return _error(1001, "Unknown channel")
         return web.json_response({"result": {}})
 
     async def task(self) -> None:

--- a/src/opcua_webhmi_bridge/messages.py
+++ b/src/opcua_webhmi_bridge/messages.py
@@ -8,6 +8,14 @@ from typing import Any, Dict, List, Union
 DataChangePayload = Union[List[Dict[str, Any]], Dict[str, Any]]
 
 
+class MessageType(str, enum.Enum):
+    """Enumeration of message types."""
+
+    OPC_DATA_CHANGE = "opc_data_change"
+    OPC_STATUS = "opc_status"
+    HEARTBEAT = "heartbeat"
+
+
 class OPCUAEncoder(json.JSONEncoder):
     """JSON encoder that recognizes OPC-UA data structures."""
 
@@ -23,10 +31,10 @@ class BaseMessage:
     """Base class for application messages.
 
     Attributes:
-        message_type: A string describing the message type.
+        message_type: A member of MessageType enum describing the message type.
     """
 
-    message_type: str = field(init=False)
+    message_type: MessageType = field(init=False)
 
     @property
     def frontend_data(self) -> Dict[str, Any]:
@@ -44,7 +52,7 @@ class OPCDataChangeMessage(BaseMessage):
         payload: The flattened representation of OPC-UA data.
     """
 
-    message_type = "opc_data_change"
+    message_type = MessageType.OPC_DATA_CHANGE
     node_id: str
     payload: DataChangePayload = field(init=False)
     ua_object: InitVar[Any]
@@ -75,7 +83,7 @@ class OPCStatusMessage(BaseMessage):
         payload: The status of OPC-UA server link.
     """
 
-    message_type = "opc_status"
+    message_type = MessageType.OPC_STATUS
     payload: LinkStatus
 
 
@@ -83,5 +91,5 @@ class OPCStatusMessage(BaseMessage):
 class HeartBeatMessage(BaseMessage):
     """Heartbeat empty message."""
 
-    message_type = "heartbeat"
+    message_type = MessageType.HEARTBEAT
     payload: None = None

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
+from unittest.mock import Mock
 
 from opcua_webhmi_bridge.messages import BaseMessage, OPCDataChangeMessage
 
 
 @dataclass
 class MessageForTesting(BaseMessage):
-    message_type = "test_message"
+    message_type = Mock()
     numeric_field: int
     text_field: str
 


### PR DESCRIPTION
* Return custom Centrifugo errors in JSON instead of HTTP errors in case of channel mismatch
* Accept wrongly rejected channels