### PR TITLE
Remove Centrifugo proxy server host binding configuration option.

### DIFF
--- a/src/opcua_webhmi_bridge/config.py
+++ b/src/opcua_webhmi_bridge/config.py
@@ -52,9 +52,6 @@ class CentrifugoSettings(BaseSettings):
     api_url: AnyHttpUrl = Field(
         "http://localhost:8000/api", help="URL of Centrifugo HTTP api"
     )
-    proxy_host: str = Field(
-        "127.0.0.1", help="Host for Centrifugo proxy server to listen on"
-    )
     proxy_port: PortField = Field(
         8008, help="Port for Centrifugo proxy server to listen on"
     )

--- a/src/opcua_webhmi_bridge/frontend_messaging.py
+++ b/src/opcua_webhmi_bridge/frontend_messaging.py
@@ -142,7 +142,7 @@ class CentrifugoProxyServer(AsyncTask):
         runner = web.AppRunner(app)
         await runner.setup()
         try:
-            site = web.TCPSite(runner, self._config.proxy_host, self._config.proxy_port)
+            site = web.TCPSite(runner, None, self._config.proxy_port)
             await site.start()
             _logger.info("Centrifugo proxy server started")
             while True:


### PR DESCRIPTION
The application is intended to run in a container, so binding to all
interfaces is safe.