### PR TITLE
Standardize timeouts in integration tests fixtures

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -95,7 +95,7 @@ def opcserver() -> OPCServer:
     start_time = datetime.now()
     while not opc_server.ping():
         elapsed = datetime.now() - start_time
-        assert elapsed.total_seconds() < 10, "Timeout trying to ping OPC-UA server"
-        time.sleep(0.1)
+        assert elapsed.total_seconds() < 30, "Timeout trying to ping OPC-UA server"
+        time.sleep(1.0)
     opc_server.reset()
     return opc_server

--- a/tests/integration/test_frontend_messaging.py
+++ b/tests/integration/test_frontend_messaging.py
@@ -40,8 +40,13 @@ class CentrifugoServer:
 @pytest.fixture
 def centrifugo_server() -> CentrifugoServer:
     server = CentrifugoServer()
+    start_time = datetime.now()
     while not server.ping():
-        time.sleep(0.1)
+        elapsed = datetime.now() - start_time
+        assert (
+            elapsed.total_seconds() < 30
+        ), "Timeout waiting for Centrifugo server to be ready"
+        time.sleep(1.0)
     return server
 
 


### PR DESCRIPTION
Should fix errors when waiting for InfluxDB